### PR TITLE
Disable generating lenses for multi-constructor types

### DIFF
--- a/src/Language/PureScript/Bridge/Printer.hs
+++ b/src/Language/PureScript/Bridge/Printer.hs
@@ -127,7 +127,7 @@ sumTypeToPrisms st = T.unlines $ map (constructorToPrism moreThan1 st) cs
 
 
 sumTypeToLenses :: SumType 'PureScript -> Text
-sumTypeToLenses st = T.unlines $ recordEntryToLens st <$> dcName <*> dcRecords
+sumTypeToLenses st@(SumType _ [_]) = T.unlines $ recordEntryToLens st <$> dcName <*> dcRecords
   where
     cs = st ^. sumTypeConstructors
     dcName = lensableConstructor ^.. traversed.sigConstructor
@@ -136,6 +136,7 @@ sumTypeToLenses st = T.unlines $ recordEntryToLens st <$> dcName <*> dcRecords
     lensableConstructor = filter singleRecordCons cs ^? _head
     singleRecordCons (DataConstructor _ (Right _)) = True
     singleRecordCons _                             = False
+sumTypeToLenses _ = ""
 
 constructorToText :: Int -> DataConstructor 'PureScript -> Text
 constructorToText _ (DataConstructor n (Left ts))  = n <> " " <> T.intercalate " " (map (typeInfoToText False) ts)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -207,3 +207,8 @@ allTests =
                           , "derive instance genericSingleValueConstr :: Generic SingleValueConstr"
                           ]
       in recTypeText `shouldBe` txt
+    it "tests generation of lenses for sum records with multiple constructors" $
+      let recType = bridgeSumType (buildBridge defaultBridge) (mkSumType (Proxy :: Proxy TwoRecords))
+          recTypeLenses = sumTypeToLenses recType
+          txt = "" -- No lenses for multi-constructors
+      in recTypeLenses `shouldBe` txt

--- a/test/TestData.hs
+++ b/test/TestData.hs
@@ -50,6 +50,16 @@ data SingleRecord a b = SingleRecord {
   , c  :: String
   } deriving(Generic, Typeable, Show)
 
+data TwoRecords
+  = FirstRecord {
+    _fra :: String
+  , _frb :: Int
+  }
+  | SecondRecord {
+    _src :: Int
+  , _srd :: [Int]
+  } deriving(Generic, Typeable, Show)
+
 newtype SomeNewtype = SomeNewtype Int
   deriving (Generic, Typeable, Show)
 


### PR DESCRIPTION
This disables the generation of lenses for types that have records with multiple constructors, such as:

```
data Twin = First { _a :: Int } | Second { _b :: String }
```
If we try to generate lenses such as `a` and `b`, the lenses have to be partial, and Purescript strongly dislikes partial functions. On the other side, I'm not sure that partial lenses are actually _proper_ lenses.